### PR TITLE
(feat) Add ability to upload images to parse

### DIFF
--- a/Server/DB/DB.js
+++ b/Server/DB/DB.js
@@ -20,7 +20,8 @@ var gameSchema = new Schema({
   3 : String,
   template: Number,
   game_started: Boolean,
-  drawing_finished: Boolean
+  drawing_finished: Boolean,
+  final_image_url: String
 });
 
 var playerSchema = new Schema({

--- a/Server/config/config.js
+++ b/Server/config/config.js
@@ -1,0 +1,2 @@
+exports.app_id = 'PASTE_THE_PARSE_APP_ID_HERE';
+exports.master_key = 'PASTE_THE_MASTER_KEY_HERE';

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "angular": "~1.4.6",
     "angular-route": "~1.4.6",
-    "angular-canvas-painter": "~0.4.0",
+    "angular-canvas-painter": "~0.5.3",
     "angular-cookies": "~1.4.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mocha": "^2.3.3",
     "mongoose": "^4.1.8",
     "morgan": "^1.1.1",
+    "node-parse-api": "^0.3.8",
     "nodemon": "^1.7.0",
     "request": "^2.36.0"
   },


### PR DESCRIPTION
- added a final_image_url field to the game schema, which will store
  the url for the image on the Parse server
- added 2 functions: 1) createBufferFromImage, which takes the image on
  our server and turns it into a buffer, and 2) uploadImageToParse, which
  uses the node-parse-api to upload a file to Parse.
- Keys can be found in Google doc here:
  https://docs.google.com/document/d/1oaLCV1ZIUVIJjhQ6i5BWXpvVBOAkqzIlTWHE
  1NV2YPY/edit
- DON'T FORGET TO RUN NPM INSTALL! :)
